### PR TITLE
Update pubspec.yaml

### DIFF
--- a/packages/mocktail/pubspec.yaml
+++ b/packages/mocktail/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   collection: ^1.17.0
-  matcher: ^0.12.13
+  matcher: 0.12.12
   test: ^1.21.7
 
 dev_dependencies:


### PR DESCRIPTION
`flutter pub get`実行時に下記エラーが発生するので、これに対応する

```bash
Because every version of mocktail from git depends on matcher ^0.12.13 and every version of flutter_test from sdk depends on matcher 0.12.12, mocktail from git is incompatible with flutter_test from sdk.
So, because awarefy depends on both flutter_test from sdk and mocktail from git, version solving failed.
```

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY/IN DEVELOPMENT/HOLD**

## Breaking Changes

YES | NO

## Description

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
